### PR TITLE
Add sync parameter for compatibility with v1.3+ of JupyterHub

### DIFF
--- a/gcpproxiesauthenticator/gcpproxiesauthenticator.py
+++ b/gcpproxiesauthenticator/gcpproxiesauthenticator.py
@@ -113,6 +113,7 @@ class ProxyUserLoginHandler(BaseHandler):
       self.write(
           self.render_template(
               self.authenticator.template_to_render,
+              sync=True,
               user=user,
               next_url=self.get_next_url(user),
           )


### PR DESCRIPTION
In v1.3.0 of JupyterHub, the signature of the method `BaseHandler.render_template()` as defined in the file `jupyterhub/handlers/base.py` was changed to include a new `sync` parameter:
https://github.com/jupyterhub/jupyterhub/compare/1.2.2...1.3.0#diff-7f097baf93f8cfafbafcfb5b4c4466d11e558d1cf89535bd32d946814317e8d5R1185

The default value of this parameter is `false` which leads to an error in the GCP proxy authenticator because the method now returns a coroutine instead of a string as before per default.

The method RequestHandler.write() as implemented in the Tornado framework where this result gets passed to expects a string, byte or dict and does not support passing in a coroutine.

By setting the new `sync` parameter to True, we can disable the async mode producing a coroutine and achieve the same behaviour as before - that is, rendering the template into a string.

Without this change, users following the tutorial https://cloud.google.com/solutions/spawning-notebook-servers-on-gke-tutorial fail when trying to spawn the Jupyter notebook, because the newest JupyterHub version will be used as the base image of the respective docker container (https://github.com/GoogleCloudPlatform/ai-notebooks-extended/blob/6f3ee51ebf58664d4bebbcde0c458342dfdf881c/gke-hub-example/docker/hub/Dockerfile#L15).
